### PR TITLE
Fix errors when parsing file paths

### DIFF
--- a/src/main/kotlin/me/urielsalis/mccrashlib/parser/JavaCrashParser.kt
+++ b/src/main/kotlin/me/urielsalis/mccrashlib/parser/JavaCrashParser.kt
@@ -15,7 +15,7 @@ class JavaCrashParser : CrashParser {
 
     override fun parse(lines: List<String>): Either<ParserError, Crash> {
         val linesWithMarker = lines.map(String::trim).filter { it.startsWith("#") }
-        val importantLine = linesWithMarker.firstOrNone { it.startsWith("# C") }
+        val importantLine = linesWithMarker.firstOrNone { it.startsWith("# C") && "[" in it && "+" in it }
         return importantLine.fold(
             { Either.left(IncompleteJavaCrash) },
             { Either.right(Crash.Java(it.substring(it.indexOf('[') + 1, it.indexOf('+')))) }


### PR DESCRIPTION
The `JAVA_CRASH_HEADER` is detected before `LAUNCHER_LOG_CONTENT`, however a launcher log could contain a java crash header too. So the reader tried to parse some launcher logs (like [this one](https://bugs.mojang.com/secure/attachment/323528/launcher_log.txt)) as a java crash report, which is actually fine. However if the java crash report in the launcher log is incomplete (doesn't have the important line), the file paths looking like `# C:\foo` in the launcher logs would be treated as the important line and make the `JavaCrashParser` crazy