### PR TITLE
Switch to JUnit 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,17 +22,25 @@ dependencies {
     implementation("com.guardsquare", "proguard-retrace", "7.1.0-beta3")
     implementation("com.fasterxml.jackson.module", "jackson-module-kotlin", "2.12.+")
 
-    testImplementation("junit", "junit", "4.12")
+    testImplementation("org.junit.jupiter", "junit-jupiter", "5.7.1")
 }
 
 configure<JavaPluginConvention> {
     sourceCompatibility = JavaVersion.VERSION_11
 }
+
 tasks {
     compileKotlin {
         kotlinOptions.jvmTarget = "11"
     }
     compileTestKotlin {
         kotlinOptions.jvmTarget = "11"
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
     }
 }


### PR DESCRIPTION
Uses JUnit 5 for unit tests. This also solves the issue that tests would still leave behind `mappings` folders in the temp folder.

For now I have edited `build.gradle.kts` to show all test results (including passed and skipped), if you want you can remove that complete line.
For the tests I have used [`@ParameterizedTest`](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests) to make the results more useful, however the Gradle output for them is currently not that great see https://github.com/gradle/gradle/issues/5975.

Additionally I have switched to the proper `assert...` methods from JUnit instead of `assert(...)` from Kotlin to get more useful error messages (at least in some cases).

Note: I have seen some occasional test failures when JUnit tried to clean up the temporary directory, but I think that is related to download failures of the mapping file.