### PR TITLE
Improve mapping file downloading

### DIFF
--- a/src/main/kotlin/me/urielsalis/mccrashlib/deobfuscator/Deobfuscator.kt
+++ b/src/main/kotlin/me/urielsalis/mccrashlib/deobfuscator/Deobfuscator.kt
@@ -3,54 +3,72 @@ package me.urielsalis.mccrashlib.deobfuscator
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import proguard.retrace.ReTrace
 import java.io.File
-import java.io.FileOutputStream
+import java.io.IOException
 import java.io.LineNumberReader
 import java.io.PrintWriter
 import java.io.StringReader
 import java.io.StringWriter
-import java.net.HttpURLConnection
+import java.net.URI
 import java.net.URL
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
 
-fun getDeobfuscation(modded: Boolean, version: String, content: String, isClient: Boolean, mappingsDirectory: File): String? {
-    if (modded) {
-        return null
-    }
-
-    if (version.isBlank() || version.contains("\\") || version.contains("/") || isZipSlip(version, mappingsDirectory)) {
+private fun getMappingFile(mappingsDirectory: File, version: String, isClient: Boolean): File? {
+    // Reject malformed or malicious names
+    if (version.isBlank() || version.contains("\\") || version.contains("/")) {
         return null
     }
 
     val name = if (isClient) {
-        "$version-client"
+        "$version-client.txt"
     } else {
-        "$version-server"
+        "$version-server.txt"
     }
 
-    val mappingFile = synchronized(mappingsDirectory) {
-        val mappingFile = File(mappingsDirectory, name)
+    val canonicalDestinationDir = mappingsDirectory.canonicalPath
+    val destinationFile = File(mappingsDirectory, name)
+    val canonicalDestinationFile = destinationFile.canonicalPath
+    // Reject if file would be outside intended directory
+    // Based on Zip Slip mitigation, see https://snyk.io/research/zip-slip-vulnerability#java
+    if (!canonicalDestinationFile.startsWith(canonicalDestinationDir + File.separator)) {
+        return null
+    }
+    return destinationFile
+}
+
+fun getDeobfuscation(
+    modded: Boolean,
+    version: String,
+    content: String,
+    isClient: Boolean,
+    mappingsDirectory: File
+): String? {
+    if (modded) {
+        return null
+    }
+
+    val mappingFile = getMappingFile(mappingsDirectory, version, isClient) ?: return null
+
+    // Synchronize to prevent race condition while downloading mapping file
+    synchronized(mappingsDirectory) {
         if (!mappingFile.exists()) {
-            downloadMapping(version, name, isClient, mappingsDirectory)
+            downloadMapping(version, mappingFile, isClient)
         }
         if (!mappingFile.exists()) {
             return null
         }
-        mappingFile
     }
     val retrace = ReTrace(ReTrace.REGULAR_EXPRESSION, false, true, mappingFile)
     val stringWriter = StringWriter()
     val printWriter = PrintWriter(stringWriter)
     retrace.retrace(LineNumberReader(StringReader(content)), printWriter)
+    printWriter.flush()
     return stringWriter.toString()
 }
 
-fun isZipSlip(version: String, mappingsDirectory: File): Boolean {
-    val canonicalDestinationDir = mappingsDirectory.canonicalPath
-    val destinationFile = File(mappingsDirectory, version)
-    val canonicalDestinationFile = destinationFile.canonicalPath
-    return !canonicalDestinationFile.startsWith(canonicalDestinationDir + File.separator)
-}
-
-private fun downloadMapping(version: String, name: String, isClient: Boolean, mappingsDirectory: File) {
+private fun downloadMapping(version: String, mappingFile: File, isClient: Boolean) {
     val mapper = jacksonObjectMapper()
     val manifest = mapper
         .readValue(URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"), VersionManifest::class.java)
@@ -64,18 +82,34 @@ private fun downloadMapping(version: String, name: String, isClient: Boolean, ma
     if (mappingUrl == null) {
         return
     }
-    downloadFile(mappingUrl, name, mappingsDirectory)
+    downloadFile(mappingUrl, mappingFile)
 }
 
-fun downloadFile(url: String, name: String, mappingsDirectory: File) {
-    val connection: HttpURLConnection = URL(url).openConnection() as HttpURLConnection
-    connection.requestMethod = "GET"
-    val stream = connection.inputStream
-    val file = File(mappingsDirectory, name)
-    file.createNewFile()
-    val out = FileOutputStream(file)
-    stream.transferTo(out)
-    out.flush()
-    out.close()
-    connection.disconnect()
+fun downloadFile(url: String, file: File) {
+    val client = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(2))
+        .build()
+    val request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .build()
+    val bodyHandler = HttpResponse.BodyHandler { responseInfo ->
+        val statusCode = responseInfo.statusCode()
+        if (statusCode == 200) {
+            HttpResponse.BodySubscribers.ofFile(file.toPath())
+        } else {
+            HttpResponse.BodySubscribers.discarding()
+        }
+    }
+
+    val response = try {
+        client.send(request, bodyHandler)
+    } catch (ioException: IOException) {
+        // Delete the file (in case it exists) since it is likely incomplete
+        file.delete()
+        throw ioException
+    }
+
+    if (response.body() == null) {
+        throw IOException("Request to $url failed with HTTP status code ${response.statusCode()}")
+    }
 }

--- a/src/test/kotlin/me/urielsalis/mccrashlib/deobfuscator/DeobfuscatorTest.kt
+++ b/src/test/kotlin/me/urielsalis/mccrashlib/deobfuscator/DeobfuscatorTest.kt
@@ -1,0 +1,23 @@
+package me.urielsalis.mccrashlib.deobfuscator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
+
+class DeobfuscatorTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["", "/", "/test", "test/", "\\test", "..", ".", "../../test", "test/../"])
+    fun testInvalidNames(childName: String) {
+        val dir = File("dir")
+        assertNull(getSafeChildPath(dir, childName))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["test", "test.txt", "test.", ".test", "test.."])
+    fun testValidNames(childName: String) {
+        val dir = File("dir")
+        assertEquals(File(dir, childName), getSafeChildPath(dir, childName))
+    }
+}


### PR DESCRIPTION
- Use Java 11's [HTTP Client](https://openjdk.java.net/groups/net/httpclient/intro.html)
Not sure if this is that useful yet, but it at least allows customizing the HTTP request more.
- Use `.txt` suffix for mapping files
- Only have one function (`getMappingFile`) for creating the mapping file path to prevent code duplication accross multiple functions.
