### PR TITLE
Detect more modded JVM crash reports

### DIFF
--- a/src/main/kotlin/com/urielsalis/mccrashlib/parser/JavaCrashParser.kt
+++ b/src/main/kotlin/com/urielsalis/mccrashlib/parser/JavaCrashParser.kt
@@ -27,8 +27,14 @@ class JavaCrashParser : CrashParser {
     }
 
     private fun isModded(lines: List<String>): Boolean {
-        // Note: Checking for any occurrence of "--tweakClass" might be error-prone in case
-        // vanilla uses it as well
-        return lines.any { it.contains("--tweakClass optifine.OptiFineTweaker") }
+        val moddedStrings = listOf(
+            // Note: Checking for any occurrence of "--tweakClass" might be error-prone in case
+            // vanilla uses it as well
+            "--tweakClass optifine.OptiFineTweaker",
+            "net.fabricmc.loader.launch.knot.KnotClient",
+            "net.fabricmc.loader.impl.launch.knot.KnotClient", // new class name
+            "--version fabric-loader-"
+        )
+        return lines.any { moddedStrings.any(it::contains) }
     }
 }


### PR DESCRIPTION
Detects JVM crash reports using Fabric. I have not added new tests for this, but you can see such a crash report in https://github.com/microsoft/openjdk/issues/76.