### PR TITLE
Extract Minecraft version from JVM crash

### DIFF
--- a/src/main/kotlin/com/urielsalis/mccrashlib/Crash.kt
+++ b/src/main/kotlin/com/urielsalis/mccrashlib/Crash.kt
@@ -23,6 +23,8 @@ sealed class Crash {
         val nativeFrames: List<JvmFrame>?,
         /** Frames of Java stack trace, in the order in which they appear in the crash report (top to bottom) */
         val javaFrames: List<JvmFrame>?,
+        /** Minecraft version ID; `null` if unknown */
+        val minecraftVersion: String?,
         /** Whether the crash report indicates that Minecraft is modded */
         val isModded: Boolean
     ) : Crash()

--- a/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/Deobfuscator.kt
+++ b/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/Deobfuscator.kt
@@ -107,12 +107,11 @@ fun getDeobfuscation(
  * @throws IllegalArgumentException if no mappings exist for the version
  */
 private fun downloadMapping(version: String, mappingFile: File, isClient: Boolean) {
-    val mapper = jacksonObjectMapper()
-    val manifest = mapper
-        .readValue(URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"), VersionManifest::class.java)
+    val manifest = fetchVersionManifest()
     val url = manifest.versions.firstOrNull { it.id == version }?.url
         // Sanitize `version` to avoid injection of untrusted text into exception message
         ?: throw IllegalArgumentException("Unknown version '${sanitize(version)}'")
+    val mapper = jacksonObjectMapper()
     val versionInfo = mapper.readValue(URL(url), VersionInfo::class.java)
     val mappingUrl = if (isClient) {
         versionInfo.downloads.clientMappings?.url

--- a/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifest.kt
+++ b/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifest.kt
@@ -1,11 +1,28 @@
 package com.urielsalis.mccrashlib.deobfuscator
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.net.URL
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class LatestVersions(
+    val release: String,
+    val snapshot: String
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class VersionManifest(
+    val latest: LatestVersions,
     val versions: List<Version>
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Version(val id: String, val url: String)
+
+fun fetchVersionManifest(): VersionManifest {
+    val mapper = jacksonObjectMapper()
+    return mapper.readValue(
+        URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"),
+        VersionManifest::class.java
+    )
+}

--- a/src/test/resources/crashes/jvm/atio6axx.dll-optifine-tweaker-parsed.txt
+++ b/src/test/resources/crashes/jvm/atio6axx.dll-optifine-tweaker-parsed.txt
@@ -71,5 +71,6 @@
   }, {
     "location" : "~StubRoutines::call_stub"
   } ],
+  "minecraftVersion" : "1.14.4-OptiFine_HD_U_F3",
   "isModded" : true
 }

--- a/src/test/resources/crashes/jvm/c-frame-without-location-parsed.txt
+++ b/src/test/resources/crashes/jvm/c-frame-without-location-parsed.txt
@@ -25,5 +25,6 @@
   }, {
     "location" : "~StubRoutines::call_stub"
   } ],
+  "minecraftVersion" : null,
   "isModded" : false
 }

--- a/src/test/resources/crashes/jvm/crash-in-log-parsed.txt
+++ b/src/test/resources/crashes/jvm/crash-in-log-parsed.txt
@@ -9,5 +9,6 @@
   },
   "nativeFrames" : null,
   "javaFrames" : null,
+  "minecraftVersion" : null,
   "isModded" : false
 }

--- a/src/test/resources/crashes/jvm/ig75icd64.dll-parsed.txt
+++ b/src/test/resources/crashes/jvm/ig75icd64.dll-parsed.txt
@@ -63,5 +63,6 @@
   }, {
     "location" : "~StubRoutines::call_stub"
   } ],
+  "minecraftVersion" : "1.6.4",
   "isModded" : false
 }

--- a/src/test/resources/crashes/jvm/internal-error-parsed.txt
+++ b/src/test/resources/crashes/jvm/internal-error-parsed.txt
@@ -55,5 +55,6 @@
     "functionOffset" : null
   } ],
   "javaFrames" : null,
+  "minecraftVersion" : null,
   "isModded" : false
 }

--- a/src/test/resources/crashes/jvm/jvm-c-frame-parsed.txt
+++ b/src/test/resources/crashes/jvm/jvm-c-frame-parsed.txt
@@ -7,5 +7,6 @@
     "location" : "[jvm.dll+0xcd36]"
   } ],
   "javaFrames" : null,
+  "minecraftVersion" : null,
   "isModded" : false
 }


### PR DESCRIPTION
Note that most test JVM crashes of this project are truncated and therefore version detection failed for them (their value is `null`).

Additionally adds the function `fetchVersionManifest()` so that it can be used by Arisa.