### PR TITLE
Parse more information from Minecraft version manifest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ group = "com.urielsalis"
 version = "2.0.7"
 
 val arrowVersion = "0.10.4"
+val jacksonVersion = "2.12.3"
 
 repositories {
     mavenCentral()
@@ -21,7 +22,8 @@ dependencies {
     implementation("io.arrow-kt", "arrow-syntax", arrowVersion)
     implementation("io.arrow-kt", "arrow-fx", arrowVersion)
     implementation("com.guardsquare", "proguard-retrace", "7.1.0-beta5")
-    implementation("com.fasterxml.jackson.module", "jackson-module-kotlin", "2.12.3")
+    implementation("com.fasterxml.jackson.module", "jackson-module-kotlin", jacksonVersion)
+    implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310", jacksonVersion)
 
     testImplementation("org.junit.jupiter", "junit-jupiter", "5.7.1")
 }

--- a/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifest.kt
+++ b/src/main/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifest.kt
@@ -1,8 +1,11 @@
 package com.urielsalis.mccrashlib.deobfuscator
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import java.net.URL
+import java.time.OffsetDateTime
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class LatestVersions(
@@ -16,11 +19,32 @@ data class VersionManifest(
     val versions: List<Version>
 )
 
+// Note: Could use Jackson's `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL`
+// in the future to protect against deserialization failure when new types are added
+enum class VersionType {
+    @JsonProperty("release")
+    RELEASE,
+    @JsonProperty("snapshot")
+    SNAPSHOT,
+    @JsonProperty("old_beta")
+    OLD_BETA,
+    @JsonProperty("old_alpha")
+    OLD_ALPHA
+}
+
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class Version(val id: String, val url: String)
+data class Version(
+    val id: String,
+    val type: VersionType,
+    val url: String,
+    val time: OffsetDateTime,
+    val releaseTime: OffsetDateTime
+)
 
 fun fetchVersionManifest(): VersionManifest {
-    val mapper = jacksonObjectMapper()
+    val mapper = jacksonMapperBuilder()
+        .addModule(JavaTimeModule())
+        .build()
     return mapper.readValue(
         URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"),
         VersionManifest::class.java

--- a/src/test/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifestTest.kt
+++ b/src/test/kotlin/com/urielsalis/mccrashlib/deobfuscator/VersionManifestTest.kt
@@ -1,0 +1,77 @@
+package com.urielsalis.mccrashlib.deobfuscator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+internal class VersionManifestTest {
+    @Test
+    fun testFetchVersionManifest() {
+        val manifest = fetchVersionManifest()
+        val latestVersions = manifest.latest
+
+        val latestRelease = manifest.versions.firstOrNull { it.id == latestVersions.release }
+        assertNotNull(latestRelease)
+        assertEquals(VersionType.RELEASE, latestRelease!!.type)
+
+        val latestSnapshot = manifest.versions.firstOrNull { it.id == latestVersions.snapshot }
+        assertNotNull(latestSnapshot)
+        assertEquals(
+            if (latestSnapshot == latestRelease) VersionType.RELEASE else VersionType.SNAPSHOT,
+            latestSnapshot!!.type
+        )
+
+        // Pick one arbitrary release version
+        val releaseVersion = manifest.versions.firstOrNull { it.id == "1.16.2" }
+        assertEquals(
+            Version(
+                "1.16.2",
+                VersionType.RELEASE,
+                "https://launchermeta.mojang.com/v1/packages/a5cd0a3e52f38c9fb713010b07f7ae89e183b0ff/1.16.2.json",
+                OffsetDateTime.parse("2022-02-25T13:15:31+00:00"),
+                OffsetDateTime.parse("2020-08-11T10:13:46+00:00")
+            ),
+            releaseVersion
+        )
+
+        // Pick one arbitrary snapshot version
+        val snapshotVersion = manifest.versions.firstOrNull { it.id == "1.16.2-rc2" }
+        assertEquals(
+            Version(
+                "1.16.2-rc2",
+                VersionType.SNAPSHOT,
+                "https://launchermeta.mojang.com/v1/packages/0bea810bb372c8f44f2946b98288e298c48edd4d/1.16.2-rc2.json",
+                OffsetDateTime.parse("2022-02-25T13:15:31+00:00"),
+                OffsetDateTime.parse("2020-08-10T11:43:36+00:00")
+            ),
+            snapshotVersion
+        )
+
+        // Pick one arbitrary old-beta version
+        val oldBetaVersion = manifest.versions.firstOrNull { it.id == "b1.5" }
+        assertEquals(
+            Version(
+                "b1.5",
+                VersionType.OLD_BETA,
+                "https://launchermeta.mojang.com/v1/packages/3fa704bd73444368f04351d6d4add8a3eead9b4e/b1.5.json",
+                OffsetDateTime.parse("2022-03-10T09:51:38+00:00"),
+                OffsetDateTime.parse("2011-04-18T22:00:00+00:00")
+            ),
+            oldBetaVersion
+        )
+
+        // Pick one arbitrary old-alpha version
+        val oldAlphaVersion = manifest.versions.firstOrNull { it.id == "rd-132328" }
+        assertEquals(
+            Version(
+                "rd-132328",
+                VersionType.OLD_ALPHA,
+                "https://launchermeta.mojang.com/v1/packages/4ec49ff663f96e78a5cf0d9538adb9d1358fc485/rd-132328.json",
+                OffsetDateTime.parse("2022-03-10T09:51:38+00:00"),
+                OffsetDateTime.parse("2009-05-13T21:28:00+00:00")
+            ),
+            oldAlphaVersion
+        )
+    }
+}


### PR DESCRIPTION
Parses more information from the Minecraft version manifest: `type`, `time` and `releaseTime`

Currently this is not needed for Arisa, but it could become useful in case we want to check for how long a version has been released already, e.g. to determine whether an attached crash report is outdated.

Note that this might be a bit brittle in case Mojang adds a new release type, though it is probably rather unlikely that this will happen.

Also, the tests for specific release, snapshot, old-beta and old-alpha version data might fail in case Mojang changes their `time` and URL retroactively. This has happened already in the past, but adjusting the tests is not so difficult, so this is probably not a big issue.